### PR TITLE
add feature to save RSS file, and headers, to disk

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -3,3 +3,4 @@ SENTRY_DSN=https://mydsn@sentry.io/123
 DATABASE_URL="postgresql:///rss-fetcher
 MAX_FEEDS=1000
 RSS_FILE_PATH=/tmp/
+SAVE_RSS_FILES=0

--- a/.gitignore
+++ b/.gitignore
@@ -114,5 +114,7 @@ __MACOSX
 *.tgz
 .DS_Store
 logs/*.log
+logs/rss-files/*.rss
+logs/rss-files/*.json
 fetcher/static/*.rss
 fetcher/static/*.gz

--- a/fetcher/__init__.py
+++ b/fetcher/__init__.py
@@ -49,10 +49,14 @@ else:
     logger.info("  DB_POOL_SIZE: {}".format(DB_POOL_SIZE))
 engine = create_engine(SQLALCHEMY_DATABASE_URI, pool_size=DB_POOL_SIZE)
 
-RSS_FILE_PATH = os.environ['RSS_FILE_PATH']
+RSS_FILE_PATH = os.environ.get('RSS_FILE_PATH')
 if RSS_FILE_PATH is None:
     logger.error("  You must set RSS_FILE_PATH env var to tell us where to store generated RSS files")
     sys.exit(1)
+
+SAVE_RSS_FILES = os.environ.get('SAVE_RSS_FILES', "0")
+SAVE_RSS_FILES = SAVE_RSS_FILES == "1"  # translate to more useful boolean value
+logger.info("  SAVE_RSS_FILES: {}".format(SAVE_RSS_FILES))
 
 
 def create_flask_app() -> Flask:

--- a/fetcher/tasks.py
+++ b/fetcher/tasks.py
@@ -48,9 +48,9 @@ def feed_worker(self, feed: Dict):
                 'statusCode': response.status_code,
                 'headers': dict(response.headers),
             }
-            with open(os.path.join(RSS_FILE_LOG_DIR, "{}-summary.json".format(feed['id'])), 'w', encoding='utf-8') as f:
+            with open(os.path.join(RSS_FILE_LOG_DIR, "{}-summary.json".format(feed['mc_media_id'])), 'w', encoding='utf-8') as f:
                 json.dump(summary, f, indent=4)
-            with open(os.path.join(RSS_FILE_LOG_DIR, "{}-content.rss".format(feed['id'])), 'w', encoding='utf-8') as f:
+            with open(os.path.join(RSS_FILE_LOG_DIR, "{}-content.rss".format(feed['mc_media_id'])), 'w', encoding='utf-8') as f:
                 f.write(response.text)
         # now process
         if response.status_code == 200:

--- a/fetcher/tasks.py
+++ b/fetcher/tasks.py
@@ -43,7 +43,9 @@ def feed_worker(self, feed: Dict):
             summary = {
                 'id': feed['id'],
                 'url': feed['url'],
-                'status_code': response.status_code,
+                'mcFeedsId': feed['mc_feeds_id'],
+                'mcMediaId': feed['mc_media_id'],
+                'statusCode': response.status_code,
                 'headers': dict(response.headers),
             }
             with open(os.path.join(RSS_FILE_LOG_DIR, "{}-summary.json".format(feed['id'])), 'w', encoding='utf-8') as f:

--- a/scripts/queue_feeds.py
+++ b/scripts/queue_feeds.py
@@ -20,7 +20,7 @@ if __name__ == '__main__':
     #  c) we attempted to fetch it, but it hasn't succeeded ever
     # AND excludes ones that have failed to respond with content 3 times in a row
     query = """
-        select id, url, last_fetch_hash, mc_media_id from feeds
+        select id, url, last_fetch_hash, mc_media_id, mc_feeds_id from feeds
         where (
             (last_fetch_attempt is NULL)
             OR


### PR DESCRIPTION
If the `SAVE_RSS_FILES` env-var is set to 1, then for each queued job two files will be created:
 * `[FEED_ID]-summary.json` - summary info and headers
 * `[FEED_ID]-content.txt` - the actual full RSS text

Sample summary JSON:
```json
{
    "id": 133746,
    "url": "https://www.destentor.nl/buitenland/rss.xml",
    "mcFeedsId": 874977,
    "mcMediaId": 38933,
    "statusCode": 200,
    "headers": {
        "Content-Type": "application/rss+xml;charset=UTF-8",
        "ETag": "W/\"09e5bea5a36ddee446052eafc7484536f\"",
        "X-Content-Type-Options": "nosniff",
        "X-XSS-Protection": "1; mode=block",
        "Strict-Transport-Security": "max-age=31536000 ; includeSubDomains",
        "Referrer-Policy": "same-origin",
        "X-Frame-Options": "DENY",
        "Content-Encoding": "gzip",
        "Content-Length": "8384",
        "Expires": "Mon, 11 Jul 2022 19:42:23 GMT",
        "Cache-Control": "max-age=0, no-cache, no-store",
        "Pragma": "no-cache",
        "Date": "Mon, 11 Jul 2022 19:42:23 GMT",
        "Connection": "keep-alive",
        "Vary": "Accept-Encoding",
        "Link": "<https://images0.persgroep.net>; rel=preconnect;"
    }
}
```