### PR TITLE
Conditional HTTP fetching

### DIFF
--- a/fetcher/database/models.py
+++ b/fetcher/database/models.py
@@ -30,6 +30,8 @@ class Feed(Base):
     last_fetch_hash = Column(String)
     last_fetch_failures = Column(Integer)
     created_at = Column(DateTime)
+    http_etag = Column(String)  # "Entity Tag"
+    http_last_modified = Column(String)
 
     def __repr__(self):
         return '<Feed id={} name={} sources_id={}>'.format(

--- a/fetcher/database/models.py
+++ b/fetcher/database/models.py
@@ -79,7 +79,7 @@ class Story(Base):
         return _run_query(query)
 
     @staticmethod
-    def from_rss_entry(feed_id: int, fetched_at: dt.datetime, entry, media_name: str = None):
+    def from_rss_entry(feed_id: int, fetched_at: dt.datetime, entry):
         s = Story()
         s.feed_id = feed_id
         try:

--- a/fetcher/database/versions/20220602_1536_update_feeds_again.py
+++ b/fetcher/database/versions/20220602_1536_update_feeds_again.py
@@ -26,5 +26,5 @@ def upgrade():
 
 
 def downgrade():
-    op.execute("DELETE from feeds WHERE import_round = 4")
+    pass
 

--- a/fetcher/database/versions/20220803_2039_drop_duplicate_feeds_ids.py
+++ b/fetcher/database/versions/20220803_2039_drop_duplicate_feeds_ids.py
@@ -18,13 +18,13 @@ depends_on = None
 
 def upgrade():
     op.drop_column('feeds', 'mc_feeds_id')
-    op.drop_column('feeds', 'import_round')
+    #op.drop_column('feeds', 'import_round')
     op.alter_column('feeds', 'mc_media_id', new_column_name='media_id')
     op.add_column('feeds', sa.Column('created_at', sa.DateTime, server_default=sa.text('NOW()')))
 
 
 def downgrade():
     op.add_column('feeds', sa.Column('mc_feeds_id', sa.BigInteger))
-    op.add_column('feeds', sa.Column('import_round', sa.Integer))
+    #op.add_column('feeds', sa.Column('import_round', sa.Integer))
     op.alter_column('feeds', 'media_id', new_column_name='mc_media_id')
     op.drop_column('feeds', 'created_at')

--- a/fetcher/database/versions/20220826_0012_add_conditional_fetch.py
+++ b/fetcher/database/versions/20220826_0012_add_conditional_fetch.py
@@ -1,0 +1,26 @@
+"""add conditional fetch
+
+Revision ID: ccbf360c92f8
+Revises: 056d7ddcf6b5
+Create Date: 2022-08-26 00:12:58.388887
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'ccbf360c92f8'
+down_revision = '056d7ddcf6b5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('feeds', sa.Column('http_etag', sa.String))
+    op.add_column('feeds', sa.Column('http_last_modified', sa.String))
+
+
+def downgrade():
+    op.drop_column('feeds', 'http_etag')
+    op.drop_column('feeds', 'http_last_modified')

--- a/fetcher/tasks.py
+++ b/fetcher/tasks.py
@@ -201,13 +201,13 @@ def fetch_feed_content(session, now: dt.datetime, feed: Dict):
         f.last_fetch_failures = 0
         session.commit()
 
-    # BAIL: server says file hasn't changed (no data returned) BEFORE looking at hash!!
+    # BAIL: *server* says file hasn't changed (no data returned) BEFORE looking at hash!!
     if response.status_code == 304:
         logger.info("  Feed {} - skipping, file not modified".format(feed['id']))
         save_fetch_event(session, feed['id'], models.FetchEvent.EVENT_FETCH_SUCCEEDED, "not modified")
         return None
 
-    # BAIL: no changes since last time
+    # BAIL: no changes since last time (based on hash of response content)
     if new_hash == feed['last_fetch_hash']:
         logger.info("  Feed {} - skipping, same hash".format(feed['id']))
         save_fetch_event(session, feed['id'], models.FetchEvent.EVENT_FETCH_SUCCEEDED, "same hash")

--- a/scripts/queue_feeds.py
+++ b/scripts/queue_feeds.py
@@ -16,7 +16,12 @@ if __name__ == '__main__':
     now = dt.datetime.now()
 
     # support passing in a specific feed id on the command line
-    arg_count = len(sys.argv)
+
+    # PLB: not adding http_{etag,last_modified} here, since time
+    # sensitive (will be wrong if feed queued more than once), instead
+    # re-fetching row in fetcher (only expects id), but keeping this
+    # unmodified to allow version mismatches.  If/Once we send only the id,
+    # could handle multiple ids on command line.
     query_start = "select id, url, last_fetch_hash, sources_id from feeds "
     feed_id = None
     try:


### PR DESCRIPTION
For initial review/comments/questions.

Implement conditional HTTP fetching for issue #16 using ETag/If-None-Match or Last-Modified/If-Modified-Since headers.  If server determines the feed has not changed they return HTTP status code 304 "Not Modified" without a response body.

Implementing the basic functionality was easy; Integrating 304 response handling is more subtle.  I've tried to leave comments about HTTP header semantics to explain my choices.
 
Note: alembic changes to allow database creation are in a single commit that I can get rid of.